### PR TITLE
fix logging crash

### DIFF
--- a/include/bat/ads/ads_client.h
+++ b/include/bat/ads/ads_client.h
@@ -37,6 +37,12 @@ enum ADS_EXPORT Result {
   FAILED
 };
 
+class ADS_EXPORT LogStream {
+ public:
+  virtual ~LogStream() = default;
+  virtual std::ostream& stream() = 0;
+};
+
 using OnSaveCallback = std::function<void(Result)>;
 using OnLoadCallback = std::function<void(Result, const std::string&)>;
 
@@ -152,7 +158,7 @@ class ADS_EXPORT AdsClient {
   virtual void EventLog(const std::string& json) = 0;
 
   // Logs debug information
-  virtual std::ostream& Log(
+  virtual std::unique_ptr<LogStream> Log(
       const char* file,
       int line,
       const LogLevel log_level) const = 0;

--- a/src/logging.h
+++ b/src/logging.h
@@ -6,6 +6,6 @@
 #define BAT_ADS_LOGGING_H_
 
 #define LOG(severity) \
-  ads_client_->Log(__FILE__, __LINE__, severity)
+  ads_client_->Log(__FILE__, __LINE__, severity)->stream()
 
 #endif  // BAT_ADS_LOGGING_H_


### PR DESCRIPTION
from chromium base/logging.h
// There's some funny
// subtle difference between ostream member streaming functions (e.g.,
// ostream::operator<<(int) and ostream non-member streaming functions
// (e.g., ::operator<<(ostream&, string&): it turns out that it's
// impossible to stream something like a string directly to an unnamed
// ostream. We employ a neat hack by calling the stream() member
// function of LogMessage which seems to avoid the problem.