### PR TITLE
Log raw PageScores list as AdsService Event

### DIFF
--- a/src/ads_impl.cc
+++ b/src/ads_impl.cc
@@ -397,6 +397,8 @@ void AdsImpl::ClassifyPage(const std::string& url, const std::string& html) {
 
   client_->AppendPageScoreToPageScoreHistory(page_score);
 
+  CachePageScore(last_shown_tab_url_, page_score);
+
   // TODO(Terry Mancey): Implement Log (#44)
   // 'Site visited', { url, immediateWinner, winnerOverTime }
 
@@ -404,7 +406,7 @@ void AdsImpl::ClassifyPage(const std::string& url, const std::string& html) {
 
   LOG(INFO) << "Site visited " << url << ", immediateWinner is "
       << winning_category << " and winnerOverTime is "
-      << winner_over_time_category << "previous tab url "
+      << winner_over_time_category << ", previous tab url "
       << last_shown_tab_url_;
 
   if (last_shown_tab_url_ == url) {


### PR DESCRIPTION
fixes https://github.com/brave-intl/bat-native-ads/issues/95

Issue was caused as we were not calling `CachePageScore` which caches a page score in memory based upon the url based upon the Muon codebase. Due to the buffer being in memory each page classification will increase the memory usage. We should consider changing this buffer to be circular with for a maximum amount of cached urls.